### PR TITLE
ci: add CodeRabbit config with assertive profile and path instructions

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,12 +1,35 @@
 language: en-US
+tone_instructions: >
+  Focus on JSON Schema 2020-12 correctness, AJV 8 usage patterns, and JSON:API
+  specification compliance for query parameter validation.
 reviews:
-  profile: chill
+  profile: assertive
   request_changes_workflow: true
   high_level_summary: true
+  high_level_summary_in_walkthrough: true
+  review_details: true
   poem: false
   review_status: true
+  related_issues: true
+  related_prs: true
+  assess_linked_issues: true
+  estimate_code_review_effort: true
+  path_instructions:
+    - path: "lib/**"
+      instructions: >
+        Core validation library. Pure ESM, AJV 8 with JSON Schema 2020-12.
+        Schema design must follow JSON:API spec for query parameters.
+        Vendored in ergo at lib/json-api-query/ — changes should be coordinated.
   auto_review:
     enabled: true
     drafts: false
 chat:
   auto_reply: true
+knowledge_base:
+  learnings:
+    scope: auto
+  linked_repositories:
+    - repository: "CentralPing/ergo"
+      instructions: >
+        ergo vendors this package at lib/json-api-query/. Schema or validation
+        changes in either repo should be synchronized.


### PR DESCRIPTION
## Summary

- Use `assertive` profile for JSON Schema validation correctness
- Add `tone_instructions` focused on JSON Schema 2020-12 and JSON:API spec compliance
- Add `path_instructions` for `lib/**` (AJV 8, vendoring coordination with ergo)
- Enable `review_details`, `related_issues`/`related_prs`, `assess_linked_issues`, `estimate_code_review_effort`
- Add `linked_repositories` for ergo (vendoring sync)
- Set `request_changes_workflow: true` (was `false`)

Supersedes the unmerged `ci/add-coderabbit-config` branch. Part of a coordinated update across all four CentralPing repos.