### PR TITLE
fix: update fast-uri to 3.1.2 (CVE remediation) (#30)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -377,9 +377,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
-      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -883,9 +883,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
## Summary

Updates transitive dependency `fast-uri` from 3.1.0 to 3.1.2 to remediate two HIGH severity CVEs:

- **GHSA-q3j6-qgpj-74h6** — Path traversal via percent-encoded dot segments
- **GHSA-v39h-62p7-jpjc** — Host confusion via percent-encoded authority delimiters

## Type

Bug fix (dependency security patch)

## Changes

- `package-lock.json`: `fast-uri` 3.1.0 → 3.1.2 (via `npm audit fix`)

## Test Plan

- [x] `npm audit --omit=dev` reports 0 vulnerabilities
- [x] `npm test` passes (73 tests, 0 failures)
- [x] Coverage thresholds met (100% across all files)

Closes #30
Related: CentralPing/ergo#43