### PR TITLE
chore: bump version to 1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.1] - 2026-05-27
+
+### Fixed
+
+- Updated fast-uri to 3.1.2 (CVE remediation).
+
+### Changed
+
+- Bumped ajv production dependency.
+
+---
+
 ## [1.0.0] - 2026-03-20
 
 ### Changed

--- a/lib/index.js
+++ b/lib/index.js
@@ -5,7 +5,7 @@
  * getter. The schema clone pattern prevents mutation from affecting the original definition.
  *
  * @module @centralping/json-api-query
- * @version 1.0.0
+ * @version 1.0.1
  * @since 1.0.0
  * @requires ./schema.json
  * @requires ./validate.js

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@centralping/json-api-query",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@centralping/json-api-query",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
         "ajv": "^8.18.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@centralping/json-api-query",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
## Summary

Bumps package version to `1.0.1` in preparation for patch release.

## Changes since `1.0.0`

- **fix:** update fast-uri to 3.1.2 — CVE remediation (#30)
- **chore(deps):** bump ajv in the production-dependencies group (#34)

## Release Process

1. Merge this PR
2. Create a GitHub Release with tag `v1.0.1` targeting `main`
3. The `release.yml` workflow will automatically publish to npm