### PR TITLE
chore: update dependabot grouping and add auto-merge for patches

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,10 +5,25 @@ updates:
     schedule:
       interval: "weekly"
     groups:
-      dev-dependencies:
+      all-patches:
+        update-types:
+          - "patch"
+      dev-minor:
         dependency-type: "development"
-      production-dependencies:
+        update-types:
+          - "minor"
+      dev-major:
+        dependency-type: "development"
+        update-types:
+          - "major"
+      prod-minor:
         dependency-type: "production"
+        update-types:
+          - "minor"
+      prod-major:
+        dependency-type: "production"
+        update-types:
+          - "major"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,25 @@
+name: Dependabot Auto-Merge
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+      - name: Approve and auto-merge patch updates
+        if: steps.metadata.outputs.update-type == 'version-update:semver-patch'
+        run: |
+          gh pr review --approve "$PR_URL"
+          gh pr merge --auto --merge "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- Updates dependabot grouping from dependency-type-only to semver-level groups: all patches combined, then dev/prod split by minor/major
- Adds auto-merge workflow that approves and enables auto-merge for patch PRs after CI passes
- Aligns configuration across all CentralPing repos

## Groups

| Group | Contents | Merge strategy |
|-------|----------|----------------|
| `all-patches` | All patch updates (dev + prod) | Auto-merged after CI |
| `dev-minor` | Dev minor updates | Manual review |
| `dev-major` | Dev major updates | Manual review |
| `prod-minor` | Prod minor updates | Manual review |
| `prod-major` | Prod major updates | Manual review |

## Auto-merge mechanism

The `dependabot-auto-merge.yml` workflow uses `dependabot/fetch-metadata` to detect semver-patch updates, then approves (satisfying branch protection's 1-review requirement) and enables auto-merge. The PR only merges after all required status checks pass.