### PR TITLE
chore: align coderabbit config with official schema

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -82,9 +82,9 @@ reviews:
         mode: "error"
         instructions: |
           Pass/fail criteria for all changed files (exclude .coderabbit.yaml itself):
-          - FAIL if new lines (added in this PR, not pre-existing) contain unresolved
-            work-marker comments (the standard incomplete-task, needs-fix, workaround,
-            and attention-needed markers).
+          - FAIL if new source code lines (added in this PR, not pre-existing) contain
+            TODO, FIXME, HACK, or XXX comments. Exclude .coderabbit.yaml and other
+            CI/CD configuration files whose instructions reference these markers by name.
           - PASS if no such markers are found in newly added lines.
           This is a pre-release project with a zero-tech-debt policy — all work is either
           done now or tracked as a GitHub issue.

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -16,12 +16,13 @@ reviews:
   sequence_diagrams: true
   review_details: true
   poem: false
+  in_progress_fortune: false
   review_status: true
   related_issues: true
   related_prs: true
   assess_linked_issues: true
   estimate_code_review_effort: true
-  prompt_for_ai_agents: true
+  enable_prompt_for_ai_agents: true
   abort_on_close: true
 
   path_instructions:
@@ -35,7 +36,7 @@ reviews:
 
   auto_review:
     enabled: true
-    auto_incremental_review: true
+    auto_incremental_review: false
     drafts: false
     ignore_title_keywords:
       - "WIP"
@@ -78,12 +79,13 @@ reviews:
             schema files changed.
 
       - name: "Zero Tech Debt"
-        mode: "warning"
+        mode: "error"
         instructions: |
-          Pass/fail criteria for all changed files:
-          - FAIL if new lines (added in this PR, not pre-existing) contain TODO, FIXME,
-            HACK, or XXX comments.
-          - PASS if no such patterns are found in newly added lines.
+          Pass/fail criteria for all changed files (exclude .coderabbit.yaml itself):
+          - FAIL if new lines (added in this PR, not pre-existing) contain unresolved
+            work-marker comments (the standard incomplete-task, needs-fix, workaround,
+            and attention-needed markers).
+          - PASS if no such markers are found in newly added lines.
           This is a pre-release project with a zero-tech-debt policy — all work is either
           done now or tracked as a GitHub issue.
 
@@ -148,7 +150,7 @@ reviews:
       enabled: false
     cppcheck:
       enabled: false
-    fortitude:
+    fortitudeLint:
       enabled: false
     fbinfer:
       enabled: false
@@ -158,13 +160,13 @@ reviews:
       enabled: false
     circleci:
       enabled: false
-    prisma-lint:
+    prismaLint:
       enabled: false
     luacheck:
       enabled: false
     brakeman:
       enabled: false
-    dotenv-lint:
+    dotenvLint:
       enabled: false
     htmlhint:
       enabled: false
@@ -172,13 +174,13 @@ reviews:
       enabled: false
     checkmake:
       enabled: false
-    osv-scanner:
-      enabled: false
+    osvScanner:
+      enabled: true
     blinter:
       enabled: false
-    smarty-lint:
+    smartyLint:
       enabled: false
-    ember-template-lint:
+    emberTemplateLint:
       enabled: false
     psscriptanalyzer:
       enabled: false
@@ -203,3 +205,11 @@ knowledge_base:
         ergo vendors this package at lib/json-api-query/. Schema or validation
         changes in either repo should be synchronized. ergo's http/json-api-query.js
         middleware wraps this module's validator.
+
+issue_enrichment:
+  auto_enrich:
+    enabled: true
+  planning:
+    enabled: true
+    auto_planning:
+      enabled: true

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,15 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    cooldown:
+      default-days: 3
+      semver-major-days: 14
+      semver-minor-days: 7
+      semver-patch-days: 3
     groups:
       all-patches:
         update-types:
@@ -28,3 +37,15 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    commit-message:
+      prefix: "ci"
+      include: "scope"
+    cooldown:
+      default-days: 3
+      semver-major-days: 14
+      semver-minor-days: 7
+    groups:
+      actions-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -42,8 +42,6 @@ updates:
       include: "scope"
     cooldown:
       default-days: 3
-      semver-major-days: 14
-      semver-minor-days: 7
     groups:
       actions-minor-patch:
         update-types:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -43,7 +43,9 @@ updates:
     cooldown:
       default-days: 3
     groups:
-      actions-minor-patch:
+      actions-patches:
+        update-types:
+          - "patch"
+      actions-minors:
         update-types:
           - "minor"
-          - "patch"


### PR DESCRIPTION
## Summary

- Fix invalid schema keys silently ignored by CodeRabbit (`prompt_for_ai_agents`, tool kebab-case keys)
- Add `in_progress_fortune: false` (correct key name, was previously absent)
- Fix 6 tool key names to match official schema (camelCase): `osvScanner`, `dotenvLint`, `prismaLint`, `smartyLint`, `emberTemplateLint`, `fortitudeLint`
- Enable `osvScanner` (was disabled under the wrong key name `osv-scanner`)
- Set `auto_incremental_review: false` (prefer manual `@coderabbitai full review`)
- Upgrade "Zero Tech Debt" check to `error` mode with indirect wording
- Add `issue_enrichment` section

## Validation

All keys validated against the [official CodeRabbit JSON schema](https://coderabbit.ai/integrations/schema.v2.json).